### PR TITLE
update custom-electron-titlebar to working version

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "@material-ui/core": "^4.12.3",
         "@material-ui/data-grid": "^4.0.0-alpha.37",
         "bootstrap": "^5.1.1",
-        "custom-electron-titlebar": "^3.2.7",
+        "custom-electron-titlebar": "^3.2.10",
         "d3": "^7.0.1",
         "mdb-react-ui-kit": "^1.4.0",
         "react": "^17.0.2",


### PR DESCRIPTION
https://github.com/austinbaccus/forza-telemetry/issues/65

However, because of react-shapes, you have to add the --legacy-peer-deps to a few commands:

```
npm install --legacy-peer-deps
```

and if you get an error about `Error: error:0308010C:digital envelope routines::unsupported`

you also need this:

```
npm update webpack --legacy-peer-deps
npm update browserslist --legacy-peer-deps
```